### PR TITLE
feat: Add support for rewriting imports in declaration files

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -103,7 +103,7 @@ export async function build({
   const reportStyles = getReportStyles();
 
   const codes = await pAll(
-    targets.map(({ extname, transpileOnly, ...target }, i) => {
+    targets.map(({ extname, dtsExtName, transpileOnly, ...target }, i) => {
       const prefix = `[${trimPrefix(extname || DEFAULT_EXTNAME, ".")}]: `;
       const prefixStyle = reportStyles[i % reportStyles.length];
 
@@ -114,6 +114,7 @@ export async function build({
           stdout,
           stderr,
           extname,
+          dtsExtName,
           target,
           reportPrefix: prefixStyle(prefix),
           transpileOnly,

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ const debug = Debug.extend("config");
 
 const targetSchema = type({
   extname: optional(string()),
+  rewriteDtsImports: optional(boolean()),
   transpileOnly: optional(boolean()),
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ const debug = Debug.extend("config");
 
 const targetSchema = type({
   extname: optional(string()),
-  rewriteDtsImports: optional(boolean()),
+  dtsExtName: optional(string()),
   transpileOnly: optional(boolean()),
 });
 

--- a/src/transformers/rewriteDtsImport.ts
+++ b/src/transformers/rewriteDtsImport.ts
@@ -18,6 +18,8 @@ export function createRewriteDtsImportTransformer(
     isStringLiteral,
     isImportDeclaration,
     isCallExpression,
+    isMappedTypeNode,
+    isTemplateLiteralTypeSpan,
     SyntaxKind,
     visitNode,
     visitEachChild,
@@ -62,7 +64,24 @@ export function createRewriteDtsImportTransformer(
   return (ctx) => {
     let sourceFile: ts.SourceFile;
 
+    const recentNodes: ts.Node[] = [];
+
     const visitor: ts.Visitor = (node) => {
+      // Add current node to the beginning of the list of recent nodes; keep 3 max.
+      if (recentNodes.unshift(node) > 3) {
+        recentNodes.pop();
+      }
+
+      // if (sourceFile.fileName.includes("schemaChangeFormat")) {
+      //   console.log(
+      //     `VISITOR [nodeKind: ${node.kind}, parent: ${
+      //       node.parent?.kind
+      //     }, text: ${(node as any)?.text}, pos: ${node.pos}]`
+      //   );
+      //   console.log(
+      //     `RECENT_NODES: ${recentNodes[0]?.kind} ${recentNodes[1]?.kind} ${recentNodes[2]?.kind}`
+      //   );
+      // }
       // ESM import
       if (isImportDeclaration(node)) {
         return factory.createImportDeclaration(
@@ -84,6 +103,77 @@ export function createRewriteDtsImportTransformer(
           updateModuleSpecifier(ctx, sourceFile, node.moduleSpecifier),
           node.assertClause
         );
+      }
+
+      // Extremely britle way to detect dynamic imports that aren't caught by
+      //   isCallExpression(node) && node.expression.kind === SyntaxKind.ImportKeyword
+      //
+      // They come up in some cases when we don't do explicit typing in source code and the type declaration files
+      // end up looking something like this:
+      //
+      //  export declare const EncodedSchemaChange: import("@sinclair/typebox").TObject<{
+      //    new: import("@sinclair/typebox").TObject<{
+      //      version: import("@sinclair/typebox").TLiteral<1>;
+      //      nodes: import("@sinclair/typebox").TRecord<import("@sinclair/typebox").TString, import("@sinclair/typebox").TObject<{
+      //      ...
+      //
+      // Tree has several cases, but the fully-defined explicit types are a nightmare to maintain.
+      if (recentNodes.length == 4) {
+        // console.log(
+        //   `CHECKING: ${isStringLiteral(node)} ${isMappedTypeNode(
+        //     recentNodes[1]
+        //   )} ${isTemplateLiteralTypeSpan(recentNodes[2])}`
+        // );
+        if (
+          isStringLiteral(node) &&
+          isMappedTypeNode(recentNodes[1]) &&
+          isTemplateLiteralTypeSpan(recentNodes[2])
+        ) {
+          // The current node is the argument to a dynamic import (i.e. `import("../..")`) of a particular kind that is
+          // not caught by other conditions in this file. We need to transform the string literal to a valid path
+          // with a file name and extension so the ESM build doesn't complain.
+
+          // if (sourceFile.fileName.includes("testRecursiveDomain")) {
+          //   console.log(
+          //     `sourceFile: ${sourceFile.fileName}, ${
+          //       node.text
+          //     }, isRelativePath: ${isRelativePath(
+          //       node.text
+          //     )}, isDirectory: ${isDirectory(
+          //       sourceFile,
+          //       node.text
+          //     )}, extname: ${extname(node.text)}`
+          //   );
+          // }
+
+          // Ignore if it's not a relative path. ".." is a relative path for our purposes but is not considered as such by
+          // isRelativePath(), so we need to let that exception fall through to the code below.
+          if (node.text !== ".." && !isRelativePath(node.text)) return node;
+
+          // Ignore if it's a JSON import
+          const ext = extname(node.text);
+          if (ext === JSON_EXT && ctx.getCompilerOptions().resolveJsonModule) {
+            return node;
+          }
+
+          let updatedModulePath: ts.StringLiteral;
+          if (isDirectory(sourceFile, node.text)) {
+            // Add /index.<ext> if it's a directory
+            updatedModulePath = factory.createStringLiteral(
+              `${node.text}/index${options.extname}`
+            );
+          } else {
+            // Replace/add the extension if it's a file
+            const base =
+              ext === JS_EXT ? trimSuffix(node.text, JS_EXT) : node.text;
+
+            updatedModulePath = factory.createStringLiteral(
+              `${base}${options.extname}`
+            );
+          }
+          // console.log(`UPDATED ${node.text} to ${updatedModulePath.text}`);
+          return updatedModulePath;
+        }
       }
 
       // ESM dynamic import

--- a/src/transformers/rewriteDtsImport.ts
+++ b/src/transformers/rewriteDtsImport.ts
@@ -142,18 +142,18 @@ export function createRewriteDtsImportTransformer(
           // not caught by other conditions in this file. We need to transform the string literal to a valid path
           // with a file name and extension so the ESM build doesn't complain.
 
-          if (sourceFile.fileName.includes("testRecursiveDomain")) {
-            console.log(
-              `sourceFile: ${sourceFile.fileName}, ${
-                node.text
-              }, isRelativePath: ${isRelativePath(
-                node.text
-              )}, isDirectory: ${isDirectory(
-                sourceFile,
-                node.text
-              )}, extname: ${extname(node.text)}`
-            );
-          }
+          // if (sourceFile.fileName.includes("testRecursiveDomain")) {
+          //   console.log(
+          //     `sourceFile: ${sourceFile.fileName}, ${
+          //       node.text
+          //     }, isRelativePath: ${isRelativePath(
+          //       node.text
+          //     )}, isDirectory: ${isDirectory(
+          //       sourceFile,
+          //       node.text
+          //     )}, extname: ${extname(node.text)}`
+          //   );
+          // }
 
           // Ignore if it's not a relative path. ".." is a relative path for our purposes but is not considered as such by
           // isRelativePath(), so we need to let that exception fall through to the code below.

--- a/src/transformers/rewriteDtsImport.ts
+++ b/src/transformers/rewriteDtsImport.ts
@@ -18,8 +18,6 @@ export function createRewriteDtsImportTransformer(
     isStringLiteral,
     isImportDeclaration,
     isCallExpression,
-    isMappedTypeNode,
-    isTemplateLiteralTypeSpan,
     SyntaxKind,
     visitNode,
     visitEachChild,
@@ -72,10 +70,9 @@ export function createRewriteDtsImportTransformer(
         recentNodes.pop();
       }
 
-      // if (sourceFile.fileName.includes("schemaChangeFormat")) {
+      // if (sourceFile.fileName.includes("testRecursiveDomain")) {
       //   console.log(
-      //     `VISITOR [nodeKind: ${node.kind}, parent: ${
-      //       node.parent?.kind
+      //     `VISITOR [nodeKind: ${node.kind}, parent: ${node.parent?.kind
       //     }, text: ${(node as any)?.text}, pos: ${node.pos}]`
       //   );
       //   console.log(
@@ -118,33 +115,45 @@ export function createRewriteDtsImportTransformer(
       //      ...
       //
       // Tree has several cases, but the fully-defined explicit types are a nightmare to maintain.
-      if (recentNodes.length == 4) {
-        // console.log(
-        //   `CHECKING: ${isStringLiteral(node)} ${isMappedTypeNode(
-        //     recentNodes[1]
-        //   )} ${isTemplateLiteralTypeSpan(recentNodes[2])}`
-        // );
+      if (recentNodes.length == 3) {
+        // if (sourceFile.fileName.includes("testRecursiveDomain")) {
+        //   console.log(
+        //     `CHECKING: ${isStringLiteral(node)} ${isMappedTypeNode(
+        //       recentNodes[1]
+        //     )} ${isTemplateLiteralTypeSpan(recentNodes[2])}`
+        //   );
+        // }
+        // NOTE: using isMappedTypeNode and isTemplateLiteralTypeSpan from options.ts was not working, returning false
+        // when the versions straight from 'ts' return true.
         if (
           isStringLiteral(node) &&
-          isMappedTypeNode(recentNodes[1]) &&
-          isTemplateLiteralTypeSpan(recentNodes[2])
+          // If we hardcode these values (200, 204), which are the ones in TS 5.1.6, things work. In TS 5.0.3, the
+          // values are 197 and 201. Compiling tsc-multi with TS 5.0.3 seems to produce build output that ends up with
+          // the older values embedded somehow (probably enums being replaced with their underlying primitive value),
+          // which makes thing not work when running with TS 5.1.6, where the node kinds will have the new values.
+          // The ideal solution uses isTemplateLiteralTypeSpan() and isMappedTypeNode() imported from the Typescript
+          // package but it runs into the same problem (I assume the function definitions that end up in the built
+          // tsc-multi have the old values hardcoded).
+          // Maybe a "deeper patch" of tsc-multi would help here, but things start getting really weird and brittle.
+          recentNodes[1].kind == 200 && // SyntaxKind.MappedType
+          recentNodes[2].kind == 204 // SyntaxKind.TemplateLiteralTypeSpan
         ) {
           // The current node is the argument to a dynamic import (i.e. `import("../..")`) of a particular kind that is
           // not caught by other conditions in this file. We need to transform the string literal to a valid path
           // with a file name and extension so the ESM build doesn't complain.
 
-          // if (sourceFile.fileName.includes("testRecursiveDomain")) {
-          //   console.log(
-          //     `sourceFile: ${sourceFile.fileName}, ${
-          //       node.text
-          //     }, isRelativePath: ${isRelativePath(
-          //       node.text
-          //     )}, isDirectory: ${isDirectory(
-          //       sourceFile,
-          //       node.text
-          //     )}, extname: ${extname(node.text)}`
-          //   );
-          // }
+          if (sourceFile.fileName.includes("testRecursiveDomain")) {
+            console.log(
+              `sourceFile: ${sourceFile.fileName}, ${
+                node.text
+              }, isRelativePath: ${isRelativePath(
+                node.text
+              )}, isDirectory: ${isDirectory(
+                sourceFile,
+                node.text
+              )}, extname: ${extname(node.text)}`
+            );
+          }
 
           // Ignore if it's not a relative path. ".." is a relative path for our purposes but is not considered as such by
           // isRelativePath(), so we need to let that exception fall through to the code below.

--- a/src/transformers/rewriteDtsImport.ts
+++ b/src/transformers/rewriteDtsImport.ts
@@ -134,7 +134,9 @@ export function createRewriteDtsImportTransformer(
           // The ideal solution uses isTemplateLiteralTypeSpan() and isMappedTypeNode() imported from the Typescript
           // package but it runs into the same problem (I assume the function definitions that end up in the built
           // tsc-multi have the old values hardcoded).
-          // Maybe a "deeper patch" of tsc-multi would help here, but things start getting really weird and brittle.
+          // Maybe a "deeper patch" of tsc-multi would help here, or building the patch with the exact TS version
+          // that we'll use to build FF (overriding the 5.0.3 tsc-multi has in its lockfile) but things start getting
+          // really weird and brittle.
           recentNodes[1].kind == 200 && // SyntaxKind.MappedType
           recentNodes[2].kind == 204 // SyntaxKind.TemplateLiteralTypeSpan
         ) {

--- a/src/transformers/rewriteImport.ts
+++ b/src/transformers/rewriteImport.ts
@@ -11,7 +11,7 @@ function isRelativePath(path: string): boolean {
 
 export interface RewriteImportTransformerOptions {
   extname: string;
-  rewriteDtsImports: boolean;
+  dtsExtName: string;
   system: ts.System;
   ts: typeof ts;
 }

--- a/src/worker/entry.ts
+++ b/src/worker/entry.ts
@@ -12,7 +12,6 @@ async function loadWorkerData(): Promise<WorkerOptions> {
   debug("Worker started");
 
   const data = await loadWorkerData();
-  data.dtsExtName = data.target.dtsExtName as string;
   debug("Target", data.target);
 
   const worker = new Worker(data);

--- a/src/worker/entry.ts
+++ b/src/worker/entry.ts
@@ -12,6 +12,7 @@ async function loadWorkerData(): Promise<WorkerOptions> {
   debug("Worker started");
 
   const data = await loadWorkerData();
+  data.dtsExtName = data.target.dtsExtName as string;
   debug("Target", data.target);
 
   const worker = new Worker(data);

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -3,6 +3,7 @@ import { Target } from "../config";
 export interface WorkerOptions {
   target: Omit<Target, "extname">;
   extname?: string;
+  dtsExtName?: string;
   verbose?: boolean;
   dry?: boolean;
   force?: boolean;

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -126,7 +126,31 @@ export class Worker {
 
   private createSystem(sys: Readonly<ts.System>): ts.System {
     const getReadPaths = (path: string) => {
-      // When reading paths, we don't want to rewrite the paths to DTS files, so we pass true to ignoreDts
+      /**
+       * When reading paths, we don't want to rewrite the paths to DTS files, so we pass `true` to ignoreDts. If we
+       * rewrite dts paths here, we get compilation failures like this:
+       *
+       * [mjs]: error TS6053: File 'FluidFramework/node_modules/.pnpm/typescript@5.1.6/node_modules/typescript/lib/lib.dom.d.ts' not found.
+       *   The file is in the program because:
+       *     Library 'lib.dom.d.ts' specified in compilerOptions
+       * [mjs]: error TS6053: File 'FluidFramework/node_modules/.pnpm/typescript@5.1.6/node_modules/typescript/lib/lib.dom.iterable.d.ts' not found.
+       *   The file is in the program because:
+       *     Library 'lib.dom.iterable.d.ts' specified in compilerOptions
+       * [mjs]: error TS6053: File 'FluidFramework/node_modules/.pnpm/typescript@5.1.6/node_modules/typescript/lib/lib.es2020.d.ts' not found.
+       *   The file is in the program because:
+       *     Library 'lib.es2020.d.ts' specified in compilerOptions
+       * [mjs]: error TS2318: Cannot find global type 'Array'.
+       * [mjs]: error TS2318: Cannot find global type 'Boolean'.
+       * [mjs]: error TS2318: Cannot find global type 'CallableFunction'.
+       * [mjs]: error TS2318: Cannot find global type 'Function'.
+       * [mjs]: error TS2318: Cannot find global type 'IArguments'.
+       * [mjs]: error TS2318: Cannot find global type 'NewableFunction'.
+       * [mjs]: error TS2318: Cannot find global type 'Number'.
+       * [mjs]: error TS2318: Cannot find global type 'Object'.
+       * [mjs]: error TS2318: Cannot find global type 'RegExp'.
+       * [mjs]: error TS2318: Cannot find global type 'String'.
+       * [mjs]: Found 13 errors.
+       */
       const paths = [this.rewritePath(path, true)];
 
       // Source files may be .js files when `allowJs` is enabled. When a .js
@@ -251,7 +275,7 @@ export class Worker {
             after: [
               createRewriteImportTransformer({
                 extname: this.data.extname || JS_EXT,
-                dtsExtName: this.data.dtsExtName ?? DTS_EXT,
+                dtsExtName: this.data.dtsExtName || DTS_EXT,
                 system: this.system,
                 ts: this.ts,
               }),
@@ -350,7 +374,7 @@ export class Worker {
       after: [
         createRewriteImportTransformer({
           extname: this.data.extname || JS_EXT,
-          dtsExtName: this.data.dtsExtName ?? DTS_EXT,
+          dtsExtName: this.data.dtsExtName || DTS_EXT,
           system: this.system,
           ts: this.ts,
         }),


### PR DESCRIPTION
This PR adds minimal support for rewriting imports in declaration (.d.ts) files by adding an "afterDeclarations" handler to supplement the existing "after" handler. To enable this feature, set the `dtsExtName` config value in the tsc-multi target config. The value should be the file extension of the declaration files you want. Sourcemap files and their references are also rewritten. Their extensions will match the configured `dtsExtName` with `.map` appended.

This is an example configuration that configures an ESNext output using the `.mjs` extension for code files and `.d.mts` extension for declaration files.

```json
{
	"targets": [
		{
			"extname": ".mjs",
			"dtsExtName": ".d.mts",
			"module": "ESNext",
			"moduleResolution": "Node16",
			"outDir": "./lib"
		}
	],
	"projects": ["tsconfig.json"]
}
```

If `dtsExtName` is omitted, behavior should match exactly what it is today without this feature.

To keep the behavior separate, I copied the existing transformer and adjusted it specifically for declarations. This way any issues with the declaration files is clearly because of the new code - it shares no functional code with the old transformer.

There is some shared code in worker.ts to rename file extensions, but even in that file most logic is clearly separated so without opting in via config, behavior should match what it is today.